### PR TITLE
Fix test loss accumulation in test loop

### DIFF
--- a/trainers/train.py
+++ b/trainers/train.py
@@ -354,7 +354,7 @@ def train_model(cfg):
             else:
                 loss_true = torch.tensor(0.0, device=fused.device)
             test_loss = loss_root + 2.0 * loss_true
-            total_test_loss += loss.item() * batch_size
+            total_test_loss += test_loss.item() * batch_size
             total_samples += batch_size
 
     print(f"Final TEST Loss: {total_test_loss / total_samples:.4f}")


### PR DESCRIPTION
## Summary
- use the computed `test_loss` when accumulating total test loss

## Testing
- `ruff check trainers/train.py | grep -n F841`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688529b2969483228990531ecd4fe3f8